### PR TITLE
fs freq reinit routine should have a reason

### DIFF
--- a/lib/sdrplay/sdrplay_source_c.cc
+++ b/lib/sdrplay/sdrplay_source_c.cc
@@ -307,7 +307,7 @@ double sdrplay_source_c::set_sample_rate(double rate) {
     std::cerr << "diff = " << diff << std::endl;
 
     if (_running) {
-        std::cerr << "reinit_device started" << std::endl;
+        _dev->reinitReson = mir_sdr_CHANGE_FS_FREQ;
         reinit_device();
 
     }
@@ -341,7 +341,6 @@ double sdrplay_source_c::set_center_freq(double freq, size_t chan) {
 
     if (_running) {
 
-        std::cerr << "reinit_device started" << std::endl;
         _dev->reinitReson = mir_sdr_CHANGE_RF_FREQ;
         reinit_device();
 


### PR DESCRIPTION
Without a reinit reason mir_sdr just skipped the instruction?
In any case, seems this fixed my problems and sampling rate is not stuck to 2.048Mhz any more.

I also removed some debug lines as they where repeating (it mis leaded me that multiple reinits are called from separate threads :) )

Closes #1 
