### PR TITLE
uninit call in class destructor

### DIFF
--- a/lib/sdrplay/sdrplay_source_c.cc
+++ b/lib/sdrplay/sdrplay_source_c.cc
@@ -110,7 +110,6 @@ sdrplay_source_c::sdrplay_source_c(const std::string &args)
                          gr::io_signature::make(MIN_IN, MAX_IN, sizeof(gr_complex)),
                          gr::io_signature::make(MIN_OUT, MAX_OUT, sizeof(gr_complex))),
           _running(false),
-          _uninit(false),
           _auto_gain(true) {
     _dev = (sdrplay_dev_t *) malloc(sizeof(sdrplay_dev_t));
     if (_dev == NULL) {
@@ -140,13 +139,11 @@ sdrplay_source_c::~sdrplay_source_c() {
 
     if (_running) {
         _running = false;
+        mir_sdr_Uninit();
     }
-    _uninit = true;
 
     if (_fifo)
     {
-        mir_sdr_Uninit();
-
         delete _fifo;
         _fifo = NULL;
     }

--- a/lib/sdrplay/sdrplay_source_c.cc
+++ b/lib/sdrplay/sdrplay_source_c.cc
@@ -139,7 +139,7 @@ sdrplay_source_c::~sdrplay_source_c() {
 
     if (_running) {
         _running = false;
-        mir_sdr_Uninit();
+        mir_sdr_StreamUninit();
     }
 
     if (_fifo)

--- a/lib/sdrplay/sdrplay_source_c.cc
+++ b/lib/sdrplay/sdrplay_source_c.cc
@@ -145,6 +145,8 @@ sdrplay_source_c::~sdrplay_source_c() {
 
     if (_fifo)
     {
+        mir_sdr_Uninit();
+
         delete _fifo;
         _fifo = NULL;
     }


### PR DESCRIPTION
I found that after I used gqrx or gnuradio and closed it, other software where not able to use sdrplay anymore. Found unsused _uninit variable, so removed it and added an actual uninit call in class destructor. Now after closing gqrx other apps can access the device without cycling the usb
